### PR TITLE
Feature: Request Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ be found at [https://hexdocs.pm/httpx](https://hexdocs.pm/httpx).
 
 ## Streaming
 
+## Changelog
+
+### 0.1.0 (2019-04-x)
+
+New features:
+
+* `HTTPX.Request` module to store request information and allow for request replays.
+* `HTTPX.Auth` can now modify more than headers.
+
+Changes:
+
+* `HTTPX.Auth` now applies to a `HTTPX.Request` and not a tuple.
+* `HTTPX.Auth` now returns a [modified] `HTTPX.Request` and not a list of headers.
+
+Optimizations:
+
+* ...
+
+Bug fixes:
+
+* ...
+
 ## License
 
 _HTTPX_ source code is released under [the MIT License](LICENSE).

--- a/lib/httpx/auth.ex
+++ b/lib/httpx/auth.ex
@@ -8,8 +8,7 @@ defmodule HTTPX.Auth do
   @doc ~S"""
   Authorizes a HTTP request using the given method, headers, body, and options.
   """
-  @callback auth(atom, String.t, [{String.t, String.t}], String.t, keyword)
-             :: [{String.t, String.t}]
+  @callback auth(HTTPX.Request.t(), Keyword.t()) :: HTTPX.Request.t()
 
   @doc false
   defmacro __using__(_opts) do

--- a/lib/httpx/auth/basic.ex
+++ b/lib/httpx/auth/basic.ex
@@ -1,17 +1,13 @@
 defmodule HTTPX.Auth.Basic do
   @moduledoc false
-
   use HTTPX.Auth
 
-  @impl true
-  def auth(_method, _url, _headers, _body, options) do
+  @impl HTTPX.Auth
+  def auth(req = %{headers: headers}, options) do
     username = options[:username]
     password = options[:password]
+    token = Base.encode64("#{username}:#{password}")
 
-    token =
-      "#{username}:#{password}"
-      |> Base.encode64
-
-    [{"authorization", "Basic " <> token}]
+    %{req | headers: [{"authorization", "Basic " <> token} | headers]}
   end
 end

--- a/lib/httpx/request.ex
+++ b/lib/httpx/request.ex
@@ -1,0 +1,124 @@
+defmodule HTTPX.Request do
+  @moduledoc ~S"""
+  A prepared HTTP request.
+
+  Can be modified by processors and replayed multiple times.
+  """
+
+  @default_auth [
+    basic: HTTPX.Auth.Basic
+  ]
+  @auth_methods Application.get_env(:httpx, :auth_extensions, []) ++ @default_auth
+
+  @default_settings [
+    ssl_options: [versions: [:"tlsv1.2"]],
+    pool: :default,
+    connect_timeout: 5_000,
+    recv_timeout: 15_000
+  ]
+
+  @user_agent "HTTPX/#{Mix.Project.config()[:version]}"
+
+  @doc false
+  @spec __default_settings__ :: Keyword.t()
+  def __default_settings__, do: @default_settings
+
+  @typedoc @moduledoc
+  @type t :: %__MODULE__{
+          method: atom,
+          url: String.t(),
+          headers: [{String.t(), String.t()}],
+          body: binary,
+          format: atom,
+          fail: boolean,
+          settings: list,
+          meta: map
+        }
+
+  defstruct [
+    :method,
+    :url,
+    :headers,
+    :body,
+    :format,
+    :fail,
+    :settings,
+    meta: %{}
+  ]
+
+  @doc ~S"""
+  Prepare a request.
+  """
+  @spec prepare(atom, String.t(), Keyword.t()) :: {:ok, t} | {:error, atom}
+  def prepare(method, url, options \\ []) do
+    request = %__MODULE__{
+      method: method,
+      url: generate_url(url, options),
+      headers: headers(options),
+      body: options[:body] || "",
+      settings: settings(options),
+      format: options[:format] || :text,
+      fail: options[:fail] || false
+    }
+
+    auth = options[:auth]
+
+    if auth_method = @auth_methods[auth] || auth do
+      auth_method.auth(request, options)
+    else
+      request
+    end
+  end
+
+  ### Helpers ###
+
+  @spec headers(Keyword.t()) :: [{String.t(), String.t()}]
+  defp headers(options) do
+    headers = options[:headers] || []
+
+    if List.keymember?(headers, "user-agent", 0),
+      do: headers,
+      else: [{"user-agent", @user_agent} | headers]
+  end
+
+  @spec settings(Keyword.t()) :: list
+  defp settings(options) do
+    hackney_settings = Keyword.merge(@default_settings, options[:settings] || [])
+
+    if options[:format] == :stream, do: hackney_settings, else: [:with_body | hackney_settings]
+  end
+
+  @spec generate_url(String.t(), Keyword.t()) :: String.t()
+  defp generate_url(url, options) do
+    uri = URI.parse(url)
+
+    full_url =
+      cond do
+        not Keyword.has_key?(options, :params) ->
+          url
+
+        uri.query ->
+          url <> "&" <> HTTPX.query_encode(options[:params] || %{})
+
+        uri.path ->
+          url <> "?" <> HTTPX.query_encode(options[:params] || %{})
+
+        true ->
+          url <> "/?" <> HTTPX.query_encode(options[:params] || %{})
+      end
+
+    full_url
+    |> to_string
+    |> default_process_url
+  end
+
+  @spec default_process_url(String.t()) :: String.t()
+  defp default_process_url(url) do
+    case url |> String.slice(0, 12) |> String.downcase() do
+      "http://" <> _ -> url
+      "https://" <> _ -> url
+      "http+unix://" <> _ -> url
+      _ -> "http://" <> url
+    end
+  end
+end

--- a/lib/httpx/request_error.ex
+++ b/lib/httpx/request_error.ex
@@ -1,4 +1,5 @@
 defmodule HTTPX.RequestError do
+  alias HTTPX.Request
   @predefined_messages []
 
   defexception [
@@ -53,7 +54,7 @@ defmodule HTTPX.RequestError do
       end,
       if exception.options[:settings] do
         hackney_settings =
-          HTTPX.__default_settings__()
+          Request.__default_settings__()
           |> Keyword.merge(exception.options[:settings])
 
         "\r\n  hackney:\r\n    " <> print_data(hackney_settings)


### PR DESCRIPTION
New features:

* `HTTPX.Request` module to store request information and allow for request replays.
* `HTTPX.Auth` can now modify more than headers.

Changes:

* `HTTPX.Auth` now applies to a `HTTPX.Request` and not a tuple.
* `HTTPX.Auth` now returns a [modified] `HTTPX.Request` and not a list of headers.
