### PR TITLE
Feature: Processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ New features:
 
 * `HTTPX.Request` module to store request information and allow for request replays.
 * `HTTPX.Auth` can now modify more than headers.
+* Processors that allow for modifications to requests on a project/application level.
 
 Changes:
 
@@ -195,7 +196,7 @@ Changes:
 
 Optimizations:
 
-* ...
+* On load HTTPX optimizes the configured processors.
 
 Bug fixes:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,114 @@ documentation.
 
 ## Processors
 
+Processors allow users to change or update requests,
+during a request lifetime.
+
+Processors are applied to all requests by `HTTPX` and
+are an ideal way to insert tracking or metrics.
+
+### Configure
+
+The processors can be given as a list, which will be applied in order.
+
+```
+config :httpx, processors: [Example.Processor]
+```
+
+Processors will be optimized on startup and can't be dynamically added or removed.
+
+If such functionality is required, then the following flag needs to be set:
+
+```
+config :httpx, dynamic: true
+```
+
+### Processor Lifetime
+
+The lifetime of a processor is:
+`init/1` => `pre_request/2` => `post_request/2` => `post_parse/2`.
+
+The `init/1`, might be called multiple times,
+but no more than once per request.
+
+### Hooks
+
+Each processor can use the following hooks:
+
+#### init/1
+
+The `init/1` hook is called to let the processor configure itself.
+
+In the optimized version the `init/1` hook is only called once.
+The `init/1` can be called once per request,
+when `:httpx` is running in dynamic mode.
+
+For example configuring a tracking header:
+```
+@impl HTTPX.Processor
+def init(opts) do
+  header = Keyword.get(opts, :tracking_header, "example")
+
+  {:ok, %{header: header}}
+end
+```
+
+#### pre_request/2
+
+The `pre_request/2` hook is called before the request is performed.
+It can be used to change
+or add to the details of a request, before it is
+performed.
+
+For example this adds a custom tracking header to all requests:
+```
+@impl HTTPX.Processor
+def pre_request(req = %{headers: headers}, %{header: header}) do
+  {:ok, %{req | headers: [{header, "..."} | headers]}}
+end
+```
+(Note the `header` comes from the `init/1` above.)
+
+#### post_request/2
+
+The `post_request/2` hook is called after the request is performed,
+but before the request is parsed.
+
+#### post_parse/2
+
+The `post_parse/2` hook is called after the request is parsed.
+
+### Example
+
+This module will redirect all requests to
+`https://ifconfig.co` and parse only the IP
+in the result.
+
+This module has no real life use and is just
+an example.
+```
+defmodule MyProcessor do
+  use HTTPX.Processor
+
+  @impl HTTPX.Processor
+  def pre_request(req, opts) do
+    {:ok, %{req | url: "https://ifconfig.co"}}
+  end
+
+  @match ~r/<code class=\"ip\">(.*)<\/code>/
+
+  @impl HTTPX.Processor
+  def post_parse(%{body: body}, _opts) do
+    case Regex.run(@match, body) do
+      [_, m] -> {:ok, m}
+      _ -> :ok
+    end
+  end
+
+  def post_parse(_, _), do: :ok
+end
+```
+
 ## Streaming
 
 ## Changelog

--- a/lib/httpx.ex
+++ b/lib/httpx.ex
@@ -450,4 +450,11 @@ defmodule HTTPX do
         raise RequestError.exception(reason, nil, context)
     end
   end
+
+  ## Optimize Process On Load ##
+
+  @on_load :optimize
+
+  @spec optimize :: :ok
+  def optimize, do: HTTPX.Process.optimize()
 end

--- a/lib/httpx/processor/process.ex
+++ b/lib/httpx/processor/process.ex
@@ -1,0 +1,163 @@
+defmodule HTTPX.Process.Helpers do
+  @moduledoc false
+  @compile {:inline, do_init: 1, do_pre_request: 2, do_post_request: 2, do_post_parse: 2}
+
+  @doc false
+  @spec do_init({module, term}) :: {module, term} | no_return
+  def do_init({k, v}) do
+    case k.init(v) do
+      {:ok, new} -> {k, new}
+      {:error, reason} -> raise "Failed to init #{k}: #{reason}"
+    end
+  end
+
+  @doc false
+  @spec do_pre_request([{module, term}], tuple) :: tuple
+  def do_pre_request([], req), do: req
+
+  def do_pre_request([{p, opts} | rest], req) do
+    case p.pre_request(req, opts) do
+      :ok -> do_pre_request(rest, req)
+      {:ok, req} -> do_pre_request(rest, req)
+      error = {:error, _} -> error
+    end
+  end
+
+  @doc false
+  @spec do_post_request([{module, term}], tuple) :: tuple
+  def do_post_request([], req), do: req
+
+  def do_post_request([{p, opts} | rest], req) do
+    case p.post_request(req, opts) do
+      :ok -> do_post_request(rest, req)
+      {:ok, req} -> do_post_request(rest, req)
+      error = {:error, _} -> error
+    end
+  end
+
+  @doc false
+  @spec do_post_parse([{module, term}], tuple) :: tuple
+  def do_post_parse([], req), do: {:ok, req}
+
+  def do_post_parse([{p, opts} | rest], req) do
+    case p.post_parse(req, opts) do
+      :ok -> do_post_parse(rest, req)
+      {:ok, req} -> do_post_parse(rest, req)
+      error = {:error, _} -> error
+    end
+  end
+end
+
+defmodule HTTPX.Process do
+  @moduledoc ~S"""
+  HTTPX process module.
+
+  Applies all processors to the HTTPX request.
+  """
+  import HTTPX.Process.Helpers
+
+  @processors :httpx
+              |> Application.get_env(:processors, [])
+              |> Enum.map(&if(is_tuple(&1), do: &1, else: {&1, []}))
+
+  # PRE REQUEST
+  @doc ~S"Apply all pre request processors."
+  @spec pre_request(HTTPX.Request.t()) :: {:ok, HTTPX.Request.t()} | {:error, term}
+  def pre_request(req),
+    do:
+      @processors
+      |> Enum.filter(fn {p, _} -> :pre_request in p.__processor__ end)
+      |> Enum.map(&do_init/1)
+      |> do_pre_request(req)
+
+  # POST REQUEST
+  @doc ~S"Apply all post request processors."
+  @spec post_request(tuple) :: {:ok, tuple} | {:error, term}
+  def post_request(req),
+    do:
+      @processors
+      |> Enum.filter(fn {p, _} -> :post_request in p.__processor__ end)
+      |> Enum.map(&do_init/1)
+      |> do_post_request(req)
+
+  # POST PARSE
+
+  @doc ~S"Apply all post parse processors."
+  @spec post_parse({:ok, HTTPX.Response.t()}) :: {:ok, HTTPX.Response.t()} | {:error, term}
+  def post_parse(req),
+    do:
+      @processors
+      |> Enum.filter(fn {p, _} -> :post_parse in p.__processor__ end)
+      |> Enum.map(&do_init/1)
+      |> do_post_parse(req)
+
+  require Logger
+
+  @doc ~S"""
+  Optimizes the `HTTPX.Process` module, unless `config :httpx, dynamic: true`.
+
+  The optimization involves optimizing the calls to all processors.
+  """
+  @spec optimize :: :ok
+  # credo:disable-for-next-line
+  def optimize do
+    if Application.get_env(:httpx, :dynamic, false) do
+      Logger.debug(fn -> "HTTPX: Optimize process (false)" end)
+      :ok
+    else
+      Logger.debug(fn -> "HTTPX: Optimize process (true)" end)
+      Code.compiler_options(ignore_module_conflict: true)
+
+      Code.compile_quoted(
+        quote do
+          defmodule HTTPX.Process do
+            @moduledoc ~S"""
+            HTTPX process module.
+
+            Applies all processors to the HTTPX request.
+            """
+            import HTTPX.Process.Helpers
+
+            @processors :httpx
+                        |> Application.get_env(:processors, [])
+                        |> Enum.map(&if(is_tuple(&1), do: &1, else: {&1, []}))
+                        |> Enum.map(&do_init/1)
+
+            # PRE REQUEST
+            @pre_request Enum.filter(@processors, fn {p, _} -> :pre_request in p.__processor__ end)
+            if Enum.count(@pre_request) > 0 do
+              def pre_request(req), do: do_pre_request(@pre_request, req)
+            else
+              def pre_request(req), do: req
+            end
+
+            # POST REQUEST
+            @post_request Enum.filter(@processors, fn {p, _} ->
+                            :post_request in p.__processor__
+                          end)
+            if Enum.count(@post_request) > 0 do
+              def post_request(req), do: do_post_request(@post_request, req)
+            else
+              def post_request(req), do: req
+            end
+
+            # POST PARSE
+            @post_parse Enum.filter(@processors, fn {p, _} -> :post_parse in p.__processor__ end)
+            if Enum.count(@post_parse) > 0 do
+              def post_parse(req), do: do_post_parse(@post_parse, req)
+            else
+              def post_parse(req), do: {:ok, req}
+            end
+
+            @spec optimize :: :ok
+            def optimize, do: :ok
+          end
+        end
+      )
+
+      Code.compiler_options(ignore_module_conflict: false)
+
+      :ok
+    end
+  end
+end

--- a/lib/httpx/processor/processor.ex
+++ b/lib/httpx/processor/processor.ex
@@ -2,6 +2,28 @@ defmodule HTTPX.Processor do
   @moduledoc ~S"""
   HTTPX processor module.
 
+  Processors allow users to change or update requests,
+  during a request lifetime.
+
+  Processors are applied to all requests by `HTTPX` and
+  are an ideal way to insert tracking or metrics.
+
+  ## Configure
+
+  The processors can be given as a list, which will be applied in order.
+
+  ```
+  config :httpx, processors: [Example.Processor]
+  ```
+
+  Processors will be optimized on startup and can't be dynamically added or removed.
+
+  If such functionality is required, then the following flag needs to be set:
+
+  ```
+  config :httpx, dynamic: true
+  ```
+
   ## Processor Lifetime
 
   The lifetime of a processor is:
@@ -86,6 +108,7 @@ defmodule HTTPX.Processor do
 
     def post_parse(_, _), do: :ok
   end
+  ```
   """
   @doc ~S"Initialize processor."
   @callback init(opts :: term) :: {:ok, opts :: term}

--- a/lib/httpx/processor/processor.ex
+++ b/lib/httpx/processor/processor.ex
@@ -1,0 +1,153 @@
+defmodule HTTPX.Processor do
+  @moduledoc ~S"""
+  HTTPX processor module.
+
+  ## Processor Lifetime
+
+  The lifetime of a processor is:
+  `init/1` => `pre_request/2` => `post_request/2` => `post_parse/2`.
+
+  The `init/1`, might be called multiple times,
+  but no more than once per request.
+
+  ## Hooks
+
+  Each processor can use the following hooks:
+
+  ### init/1
+
+  The `init/1` hook is called to let the processor configure itself.
+
+  In the optimized version the `init/1` hook is only called once.
+  The `init/1` can be called once per request,
+  when `:httpx` is running in dynamic mode.
+
+  For example configuring a tracking header:
+  ```
+  @impl HTTPX.Processor
+  def init(opts) do
+    header = Keyword.get(opts, :tracking_header, "example")
+
+    {:ok, %{header: header}}
+  end
+  ```
+
+  ### pre_request/2
+
+  The `pre_request/2` hook is called before the request is performed.
+  It can be used to change
+  or add to the details of a request, before it is
+  performed.
+
+  For example this adds a custom tracking header to all requests:
+  ```
+  @impl HTTPX.Processor
+  def pre_request(req = %{headers: headers}, %{header: header}) do
+    {:ok, %{req | headers: [{header, "..."} | headers]}}
+  end
+  ```
+  (Note the `header` comes from the `init/1` above.)
+
+  ### post_request/2
+
+  The `post_request/2` hook is called after the request is performed,
+  but before the request is parsed.
+
+  ### post_parse/2
+
+  The `post_parse/2` hook is called after the request is parsed.
+
+  ## Example
+
+  This module will redirect all requests to
+  `https://ifconfig.co` and parse only the IP
+  in the result.
+
+  This module has no real life use and is just
+  an example.
+  ```
+  defmodule MyProcessor do
+    use HTTPX.Processor
+
+    @impl HTTPX.Processor
+    def pre_request(req, opts) do
+      {:ok, %{req | url: "https://ifconfig.co"}}
+    end
+
+    @match ~r/<code class=\"ip\">(.*)<\/code>/
+
+    @impl HTTPX.Processor
+    def post_parse(%{body: body}, _opts) do
+      case Regex.run(@match, body) do
+        [_, m] -> {:ok, m}
+        _ -> :ok
+      end
+    end
+
+    def post_parse(_, _), do: :ok
+  end
+  """
+  @doc ~S"Initialize processor."
+  @callback init(opts :: term) :: {:ok, opts :: term}
+
+  @doc ~S"Pre request processor."
+  @callback pre_request(HTTPX.Request.t(), opts :: term) :: :ok
+
+  @doc ~S"Post request processor."
+  @callback post_request(any, opts :: term) :: :ok
+
+  @doc ~S"Post parse processor."
+  @callback post_parse(any, opts :: term) :: :ok
+
+  @doc false
+  @callback __processor__ :: [atom]
+
+  @overridable [init: 1, pre_request: 2, post_request: 2, post_parse: 2]
+
+  @doc @moduledoc
+  defmacro __using__(_ \\ []) do
+    quote location: :keep do
+      Module.register_attribute(__MODULE__, :processor_impl, accumulate: true)
+      @before_compile unquote(__MODULE__)
+      @behaviour unquote(__MODULE__)
+
+      @doc ~S"Initialize processor."
+      @impl unquote(__MODULE__)
+      def init(opts), do: {:ok, opts}
+
+      @doc ~S"Pre request processor."
+      @impl unquote(__MODULE__)
+      def pre_request(_req, _opts), do: :ok
+
+      @doc ~S"Post request processor."
+      @impl unquote(__MODULE__)
+      def post_request(_result, _opts), do: :ok
+
+      @doc ~S"Post parse processor."
+      @impl unquote(__MODULE__)
+      def post_parse(_req, _opts), do: :ok
+
+      defoverridable unquote(@overridable)
+      @on_definition {unquote(__MODULE__), :track_impl}
+    end
+  end
+
+  @doc false
+  @spec track_impl(any, :def | :defp, atom, [atom], any, any) :: any
+  def track_impl(env, :def, name, args, _guards, _body) do
+    if {name, Enum.count(args)} in @overridable do
+      Module.put_attribute(env.module, :processor_impl, name)
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    implemented = Module.get_attribute(env.module, :processor_impl) || []
+
+    quote do
+      @doc false
+      @impl unquote(__MODULE__)
+      def __processor__, do: unquote(implemented)
+    end
+  end
+end


### PR DESCRIPTION
  HTTPX processor module.

  Processors allow users to change or update requests,
  during a request lifetime.

  Processors are applied to all requests by `HTTPX` and
  are an ideal way to insert tracking or metrics.

  ## Configure

  The processors can be given as a list, which will be applied in order.

  ```
  config :httpx, processors: [Example.Processor]
  ```

  Processors will be optimized on startup and can't be dynamically added or removed.

  If such functionality is required, then the following flag needs to be set:

  ```
  config :httpx, dynamic: true
  ```

  ## Processor Lifetime

  The lifetime of a processor is:
  `init/1` => `pre_request/2` => `post_request/2` => `post_parse/2`.

  The `init/1`, might be called multiple times,
  but no more than once per request.

  ## Hooks

  Each processor can use the following hooks:

  ### init/1

  The `init/1` hook is called to let the processor configure itself.

  In the optimized version the `init/1` hook is only called once.
  The `init/1` can be called once per request,
  when `:httpx` is running in dynamic mode.

  For example configuring a tracking header:
  ```
  @impl HTTPX.Processor
  def init(opts) do
    header = Keyword.get(opts, :tracking_header, "example")

    {:ok, %{header: header}}
  end
  ```

  ### pre_request/2

  The `pre_request/2` hook is called before the request is performed.
  It can be used to change
  or add to the details of a request, before it is
  performed.

  For example this adds a custom tracking header to all requests:
  ```
  @impl HTTPX.Processor
  def pre_request(req = %{headers: headers}, %{header: header}) do
    {:ok, %{req | headers: [{header, "..."} | headers]}}
  end
  ```
  (Note the `header` comes from the `init/1` above.)

  ### post_request/2

  The `post_request/2` hook is called after the request is performed,
  but before the request is parsed.

  ### post_parse/2

  The `post_parse/2` hook is called after the request is parsed.

  ## Example

  This module will redirect all requests to
  `https://ifconfig.co` and parse only the IP
  in the result.

  This module has no real life use and is just
  an example.
  ```
  defmodule MyProcessor do
    use HTTPX.Processor

    @impl HTTPX.Processor
    def pre_request(req, opts) do
      {:ok, %{req | url: "https://ifconfig.co"}}
    end

    @match ~r/<code class=\"ip\">(.*)<\/code>/

    @impl HTTPX.Processor
    def post_parse(%{body: body}, _opts) do
      case Regex.run(@match, body) do
        [_, m] -> {:ok, m}
        _ -> :ok
      end
    end

    def post_parse(_, _), do: :ok
  end
  ```